### PR TITLE
fix: adjust browserslist targets for Netlify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 2 Chrome versions",
+      "last 2 Firefox versions",
+      "last 2 Safari versions",
+      "last 2 Edge versions",
+      "not dead"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
## Summary
This PR updates the production browserslist targets to avoid the Babel target error for `opera_mobile` during Netlify builds.

## Changes
- Updated production targets in `package.json` to explicitly list supported modern browsers (Chrome, Firefox, Safari, Edge).
- Removed the previous broad query set that resolved to an invalid Babel target in the Netlify environment.

## Validation
- Local build completes successfully with `yarn build`.
- Branch `fix/netlify-babel-opera-mobile` is pushed to origin.

## Notes
After merge, trigger a new Netlify deploy (and clear cache if needed).